### PR TITLE
feat: add MCP server and dev launch configurations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js Dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- shadcn MCP サーバー設定 (`.mcp.json`) を追加
- `.claude/launch.json` に Next.js dev サーバー設定を追加

## Test plan
- [ ] `claude/bold-ellis` → `develop` は PR #1 でマージ済み
- [ ] shadcn MCP が Claude Code で使用できることを確認
- [ ] `npm run dev` でサーバーが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)