### PR TITLE
feat(ui): HeroUI Meter・空状態UI・Animate UI CountingNumber を導入

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,13 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "shadcn": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "shadcn@latest",
+        "mcp"
+      ],
+      "env": {}
+    }
+  }
 }

--- a/app/ads/page.tsx
+++ b/app/ads/page.tsx
@@ -20,7 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon } from 'lucide-react';
+import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import {
   ADS,
@@ -240,6 +241,13 @@ export default function AdsListPage() {
         {/* テーブル */}
         <Card>
           <CardContent className="p-0">
+            {filtered.length === 0 ? (
+              <EmptyState
+                icon={SearchXIcon}
+                title="該当する広告がありません"
+                description="フィルター条件を変更してお試しください"
+              />
+            ) : (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -381,6 +389,7 @@ export default function AdsListPage() {
                 </TableRow>
               </TableFooter>
             </Table>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -18,6 +18,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { InfoIcon, CheckIcon, XIcon } from 'lucide-react'
+import { Meter } from '@heroui/react'
 
 const fmt = (n: number) =>
   new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY', maximumFractionDigits: 0 }).format(n)
@@ -160,11 +161,11 @@ export default function BudgetPage() {
     }
   }
 
-  const utilizationColor = (u: number) =>
-    u > 90 ? 'bg-red-500' : u > 75 ? 'bg-amber-500' : 'bg-emerald-500'
+  const utilizationMeterColor = (u: number): 'success' | 'warning' | 'danger' =>
+    u > 100 ? 'danger' : u > 80 ? 'warning' : 'success'
 
   const utilizationBadge = (u: number): 'destructive' | 'warning' | 'success' =>
-    u > 90 ? 'destructive' : u > 75 ? 'warning' : 'success'
+    u > 100 ? 'destructive' : u > 80 ? 'warning' : 'success'
 
   return (
     <MainLayout>
@@ -226,16 +227,17 @@ export default function BudgetPage() {
               </CardHeader>
               <CardContent>
                 <p className="text-2xl font-semibold tabular-nums">{fmtPct(totalUtilization)}</p>
-                <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
-                  <div
-                    className={`h-full rounded-full transition-all ${utilizationColor(totalUtilization)}`}
-                    style={{ width: `${Math.min(100, totalUtilization)}%` }}
-                    role="progressbar"
-                    aria-valuenow={totalUtilization}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                  />
-                </div>
+                <Meter
+                  aria-label="総消化率"
+                  value={Math.min(100, totalUtilization)}
+                  maxValue={100}
+                  color={utilizationMeterColor(totalUtilization)}
+                  className="mt-2 w-full"
+                >
+                  <Meter.Track>
+                    <Meter.Fill />
+                  </Meter.Track>
+                </Meter>
               </CardContent>
             </Card>
           </div>
@@ -257,17 +259,17 @@ export default function BudgetPage() {
                       <span className="ml-2 font-medium">{fmtPct(utilization)}</span>
                     </span>
                   </div>
-                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                    <div
-                      className={`h-full rounded-full ${utilizationColor(utilization)}`}
-                      style={{ width: `${Math.min(100, utilization)}%` }}
-                      role="progressbar"
-                      aria-valuenow={utilization}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                      aria-label={`${PLATFORM_LABELS[platform]} 消化率`}
-                    />
-                  </div>
+                  <Meter
+                    aria-label={`${PLATFORM_LABELS[platform]} 消化率`}
+                    value={Math.min(100, utilization)}
+                    maxValue={100}
+                    color={utilizationMeterColor(utilization)}
+                    className="w-full"
+                  >
+                    <Meter.Track>
+                      <Meter.Fill />
+                    </Meter.Track>
+                  </Meter>
                 </div>
               ))}
             </CardContent>
@@ -362,16 +364,18 @@ export default function BudgetPage() {
                         <TableCell className="text-right tabular-nums text-sm">{fmt(c.remaining)}</TableCell>
                         <TableCell>
                           <div className="flex items-center gap-2">
-                            <div className="flex-1 h-1.5 overflow-hidden rounded-full bg-muted">
-                              <div
-                                className={`h-full rounded-full ${utilizationColor(c.utilization)}`}
-                                style={{ width: `${Math.min(100, c.utilization)}%` }}
-                                role="progressbar"
-                                aria-valuenow={c.utilization}
-                                aria-valuemin={0}
-                                aria-valuemax={100}
-                              />
-                            </div>
+                            <Meter
+                              aria-label={`${c.name} 消化率`}
+                              value={Math.min(100, c.utilization)}
+                              maxValue={100}
+                              size="sm"
+                              color={utilizationMeterColor(c.utilization)}
+                              className="flex-1"
+                            >
+                              <Meter.Track>
+                                <Meter.Fill />
+                              </Meter.Track>
+                            </Meter>
                             <Badge variant={utilizationBadge(c.utilization)} className="tabular-nums text-xs">
                               {fmtPct(c.utilization)}
                             </Badge>

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -20,7 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon } from 'lucide-react';
+import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import { CAMPAIGNS, type CampaignData, type CampaignStatus, type Platform, type AdType } from '@/lib/campaign-mock-data';
 
@@ -252,6 +253,13 @@ export default function CampaignsPage() {
         {/* テーブル */}
         <Card>
           <CardContent className="p-0">
+            {filtered.length === 0 ? (
+              <EmptyState
+                icon={SearchXIcon}
+                title="該当するキャンペーンがありません"
+                description="フィルター条件を変更してお試しください"
+              />
+            ) : (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -397,6 +405,7 @@ export default function CampaignsPage() {
                 </TableRow>
               </TableFooter>
             </Table>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/creatives/page.tsx
+++ b/app/creatives/page.tsx
@@ -18,7 +18,8 @@ import {
   DialogFooter,
   DialogClose,
 } from '@/components/ui/dialog'
-import { PlusIcon, PauseIcon, PlayIcon, Trash2Icon, InfoIcon } from 'lucide-react'
+import { PlusIcon, PauseIcon, PlayIcon, Trash2Icon, InfoIcon, SearchXIcon } from 'lucide-react'
+import { EmptyState } from '@/components/ui/empty-state'
 
 interface Creative {
   id: string
@@ -321,9 +322,12 @@ export default function CreativesPage() {
               })}
 
           {!loading && creatives.length === 0 && (
-            <div className="col-span-full flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
-              <PlusIcon className="size-8 opacity-40" aria-hidden="true" />
-              <p className="text-sm">条件に合うクリエイティブがありません</p>
+            <div className="col-span-full">
+              <EmptyState
+                icon={SearchXIcon}
+                title="該当するクリエイティブがありません"
+                description="フィルター条件を変更してお試しください"
+              />
             </div>
           )}
         </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -39,7 +39,8 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { Chip } from '@heroui/react';
+import { Chip, Meter } from '@heroui/react';
+import { CountingNumber } from '@/components/animate-ui/counting-number';
 import { cn } from '@/lib/utils';
 import {
   aggregateCampaigns,
@@ -300,6 +301,10 @@ function TargetBadge({
 function KpiCard({
   title,
   value,
+  rawValue,
+  format,
+  decimalPlaces,
+  fallback,
   sub,
   icon: Icon,
   delta,
@@ -311,7 +316,11 @@ function KpiCard({
   onSetTarget,
 }: {
   title: string;
-  value: string;
+  value?: string;
+  rawValue?: number | null;
+  format?: (v: number) => string;
+  decimalPlaces?: number;
+  fallback?: string;
   sub?: string;
   icon: React.ElementType;
   delta?: number | null;
@@ -348,7 +357,18 @@ function KpiCard({
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <p className="text-sm text-muted-foreground">{title}</p>
-            <p className="text-2xl font-bold mt-1 tabular-nums tracking-tight">{value}</p>
+            <p className="text-2xl font-bold mt-1 tabular-nums tracking-tight">
+              {rawValue != null && format ? (
+                <CountingNumber
+                  number={rawValue}
+                  format={format}
+                  decimalPlaces={decimalPlaces ?? 0}
+                  transition={{ stiffness: 120, damping: 30 }}
+                />
+              ) : (
+                value ?? fallback ?? '—'
+              )}
+            </p>
 
             {/* 目標比表示 */}
             {onSetTarget && (
@@ -939,7 +959,8 @@ export default function DashboardPage() {
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
           <KpiCard
             title="総費用"
-            value={jpyFormat.format(Math.round(current.cost))}
+            rawValue={Math.round(current.cost)}
+            format={(v) => jpyFormat.format(v)}
             sub="期間累計"
             icon={Wallet}
             delta={calcDelta(current.cost, previous.cost)}
@@ -947,7 +968,8 @@ export default function DashboardPage() {
           />
           <KpiCard
             title="CV数"
-            value={numFormat.format(Math.round(current.conversions))}
+            rawValue={Math.round(current.conversions)}
+            format={(v) => numFormat.format(v)}
             icon={Target}
             delta={calcDelta(current.conversions, previous.conversions)}
             deltaLabel={deltaLabel}
@@ -958,7 +980,9 @@ export default function DashboardPage() {
           />
           <KpiCard
             title="CPA"
-            value={current.cpa > 0 ? jpyFormat.format(Math.round(current.cpa)) : '—'}
+            rawValue={current.cpa > 0 ? Math.round(current.cpa) : null}
+            format={(v) => jpyFormat.format(v)}
+            fallback="—"
             icon={TrendingUp}
             delta={calcDelta(current.cpa, previous.cpa)}
             lowerIsBetter
@@ -970,7 +994,10 @@ export default function DashboardPage() {
           />
           <KpiCard
             title="CVR"
-            value={current.cvr > 0 ? pctFormat.format(current.cvr) : '—'}
+            rawValue={current.cvr > 0 ? current.cvr : null}
+            format={(v) => pctFormat.format(v)}
+            decimalPlaces={4}
+            fallback="—"
             sub="クリック→CV率"
             icon={MousePointerClick}
             delta={calcDelta(current.cvr, previous.cvr)}
@@ -1181,7 +1208,12 @@ export default function DashboardPage() {
         {/* ─── 媒体別サマリー（全媒体時のみ） ─── */}
         {platform === 'all' && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-            {(isMock ? mockSummary.byPlatform : byPlatform).map((s) => (
+            {(isMock ? mockSummary.byPlatform : byPlatform).map((s) => {
+              const budgetRow = budget?.byPlatform.find((b) => b.platform === s.platform);
+              const utilPct = budgetRow ? budgetRow.utilization * 100 : null;
+              const meterColor: 'success' | 'warning' | 'danger' =
+                utilPct == null ? 'success' : utilPct > 100 ? 'danger' : utilPct > 80 ? 'warning' : 'success';
+              return (
               <Card key={s.platform}>
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base flex items-center gap-2">
@@ -1234,9 +1266,34 @@ export default function DashboardPage() {
                       </p>
                     </div>
                   </div>
+                  {budgetRow && utilPct != null && (
+                    <div className="mt-4 pt-3 border-t border-border/50 space-y-1.5">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">予算消化率</span>
+                        <span className="tabular-nums font-medium">
+                          {pct1Format.format(budgetRow.utilization)}
+                          <span className="text-muted-foreground/60 ml-1">
+                            （{jpyCompact.format(budgetRow.spent)} / {jpyCompact.format(budgetRow.budget)}）
+                          </span>
+                        </span>
+                      </div>
+                      <Meter
+                        aria-label={`${PLATFORM_LABELS[s.platform]} 予算消化率`}
+                        value={Math.min(100, utilPct)}
+                        maxValue={100}
+                        size="sm"
+                        color={meterColor}
+                        className="w-full"
+                      >
+                        <Meter.Track>
+                          <Meter.Fill />
+                        </Meter.Track>
+                      </Meter>
+                    </div>
+                  )}
                 </CardContent>
               </Card>
-            ))}
+            );})}
           </div>
         )}
       </div>

--- a/app/keywords/page.tsx
+++ b/app/keywords/page.tsx
@@ -20,7 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon } from 'lucide-react';
+import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import {
   KEYWORDS,
@@ -241,6 +242,13 @@ export default function KeywordsListPage() {
         {/* テーブル */}
         <Card>
           <CardContent className="p-0">
+            {filtered.length === 0 ? (
+              <EmptyState
+                icon={SearchXIcon}
+                title="該当するキーワードがありません"
+                description="フィルター条件を変更してお試しください"
+              />
+            ) : (
             <Table>
               <TableHeader>
                 <TableRow>
@@ -388,6 +396,7 @@ export default function KeywordsListPage() {
                 </TableRow>
               </TableFooter>
             </Table>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/search-terms/page.tsx
+++ b/app/search-terms/page.tsx
@@ -16,7 +16,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { InfoIcon, ArrowUpIcon, ArrowDownIcon, MinusIcon } from 'lucide-react'
+import { InfoIcon, ArrowUpIcon, ArrowDownIcon, MinusIcon, SearchXIcon } from 'lucide-react'
+import { EmptyState } from '@/components/ui/empty-state'
 
 interface SearchTerm {
   id: string
@@ -209,6 +210,12 @@ export default function SearchTermsPage() {
               <div className="space-y-2 p-4">
                 {[0, 1, 2, 3, 4].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
               </div>
+            ) : terms.length === 0 ? (
+              <EmptyState
+                icon={SearchXIcon}
+                title="該当する検索語句がありません"
+                description="フィルター条件を変更してお試しください"
+              />
             ) : (
               <Table>
                 <TableHeader>
@@ -272,13 +279,6 @@ export default function SearchTermsPage() {
                     )
                   })}
 
-                  {terms.length === 0 && (
-                    <TableRow>
-                      <TableCell colSpan={9} className="py-10 text-center text-sm text-muted-foreground">
-                        データがありません
-                      </TableCell>
-                    </TableRow>
-                  )}
                 </TableBody>
               </Table>
             )}

--- a/components/animate-ui/counting-number.tsx
+++ b/components/animate-ui/counting-number.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import * as React from 'react'
+import { useMotionValue, useSpring, type SpringOptions } from 'motion/react'
+
+import { useIsInView, type UseIsInViewOptions } from '@/hooks/use-is-in-view'
+
+export type CountingNumberProps = Omit<React.ComponentProps<'span'>, 'children'> & {
+  number: number
+  fromNumber?: number
+  padStart?: boolean
+  decimalSeparator?: string
+  decimalPlaces?: number
+  transition?: SpringOptions
+  delay?: number
+  initiallyStable?: boolean
+  format?: (value: number) => string
+} & UseIsInViewOptions
+
+export function CountingNumber({
+  ref,
+  number,
+  fromNumber = 0,
+  padStart = false,
+  inView = false,
+  inViewMargin = '0px',
+  inViewOnce = true,
+  decimalSeparator = '.',
+  transition = { stiffness: 90, damping: 50 },
+  decimalPlaces = 0,
+  delay = 0,
+  initiallyStable = false,
+  format,
+  ...props
+}: CountingNumberProps) {
+  const { ref: localRef, isInView } = useIsInView(
+    ref as React.Ref<HTMLElement>,
+    { inView, inViewOnce, inViewMargin },
+  )
+
+  const numberStr = number.toString()
+  const decimals =
+    typeof decimalPlaces === 'number'
+      ? decimalPlaces
+      : numberStr.includes('.')
+        ? (numberStr.split('.')[1]?.length ?? 0)
+        : 0
+
+  const motionVal = useMotionValue(initiallyStable ? number : fromNumber)
+  const springVal = useSpring(motionVal, transition)
+
+  const finalIntLength = Math.floor(Math.abs(number)).toString().length
+
+  const formatValue = React.useCallback(
+    (val: number) => {
+      if (format) return format(decimals > 0 ? val : Math.round(val))
+      let out = decimals > 0 ? val.toFixed(decimals) : Math.round(val).toString()
+      if (decimals > 0) out = out.replace('.', decimalSeparator)
+      if (padStart) {
+        const [intPart, fracPart] = out.split(decimalSeparator)
+        const paddedInt = (intPart ?? '').padStart(finalIntLength, '0')
+        out = fracPart ? `${paddedInt}${decimalSeparator}${fracPart}` : paddedInt
+      }
+      return out
+    },
+    [decimals, decimalSeparator, padStart, finalIntLength, format],
+  )
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (isInView) motionVal.set(number)
+    }, delay)
+    return () => clearTimeout(timeoutId)
+  }, [isInView, number, motionVal, delay])
+
+  React.useEffect(() => {
+    const unsubscribe = springVal.on('change', (latest) => {
+      if (localRef.current) {
+        localRef.current.textContent = formatValue(latest)
+      }
+    })
+    return () => unsubscribe()
+  }, [springVal, formatValue, localRef])
+
+  const initialText = initiallyStable
+    ? formatValue(number)
+    : format
+      ? format(0)
+      : padStart
+        ? '0'.padStart(finalIntLength, '0') + (decimals > 0 ? decimalSeparator + '0'.repeat(decimals) : '')
+        : '0' + (decimals > 0 ? decimalSeparator + '0'.repeat(decimals) : '')
+
+  return (
+    <span ref={localRef} data-slot="counting-number" {...props}>
+      {initialText}
+    </span>
+  )
+}

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,35 @@
+import type { ComponentType, ReactNode } from 'react'
+import type { LucideProps } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface EmptyStateProps {
+  icon?: ComponentType<LucideProps>
+  title: string
+  description?: string
+  action?: ReactNode
+  className?: string
+}
+
+export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 px-6 py-14 text-center',
+        className,
+      )}
+    >
+      {Icon && (
+        <div className="rounded-full bg-muted/60 p-3">
+          <Icon className="size-6 text-muted-foreground/70" aria-hidden="true" />
+        </div>
+      )}
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{title}</p>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  )
+}

--- a/hooks/use-is-in-view.ts
+++ b/hooks/use-is-in-view.ts
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { useInView, type UseInViewOptions } from 'motion/react'
+
+export interface UseIsInViewOptions {
+  inView?: boolean
+  inViewOnce?: boolean
+  inViewMargin?: UseInViewOptions['margin']
+}
+
+export function useIsInView<T extends HTMLElement = HTMLElement>(
+  ref: React.Ref<T> | undefined,
+  options: UseIsInViewOptions = {},
+) {
+  const { inView, inViewOnce = false, inViewMargin = '0px' } = options
+  const localRef = React.useRef<T>(null)
+  React.useImperativeHandle(ref, () => localRef.current as T)
+  const inViewResult = useInView(localRef, {
+    once: inViewOnce,
+    margin: inViewMargin,
+  })
+  const isInView = !inView || inViewResult
+  return { ref: localRef, isInView }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
         "lucide-react": "^1.7.0",
+        "motion": "^12.23.22",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -6135,6 +6136,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -7409,6 +7437,47 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.3.1",
     "lucide-react": "^1.7.0",
+    "motion": "^12.23.22",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary

運用ダッシュボードの視認性と操作感を底上げするため、UI/UX 改善 Issue のうち優先度高の 3 件をまとめて実装しました。

- **HeroUI Meter で予算消化率をゲージ化** (closes #13)
- **空状態 (Empty State) UI を統一** (closes #14)
- **Animate UI CountingNumber を KPI に導入** (closes #18)

## 変更内容

### 1. HeroUI Meter (#13)
- `app/budget/page.tsx`: 総消化率・媒体別・キャンペーン行の 3 箇所の div ベースバーを `<Meter>` に置換
- `app/dashboard/page.tsx`: 媒体別サマリーカードに予算消化 Meter を新規追加
- しきい値を `80% → warning / 100% → danger` に統一

### 2. Empty State 統一 (#14)
- 新規: `components/ui/empty-state.tsx` (`icon` / `title` / `description` / `action`)
- 適用: `campaigns` / `keywords` / `ads` / `search-terms` / `creatives`
- `search-terms` の colSpan セルと `creatives` の独自 div も新コンポーネントに統一

### 3. Animate UI CountingNumber (#18)
- 新規: `hooks/use-is-in-view.ts`, `components/animate-ui/counting-number.tsx`
- Animate UI 本家をベースに `format` prop を拡張し `Intl.NumberFormat('ja-JP')` に対応
- `KpiCard` に `rawValue` / `format` / `fallback` props を追加、ダッシュボード 4 KPI（総費用 / CV / CPA / CVR）でロード時・期間切替時にカウントアップ

### 依存追加
- `motion` ^12.23.22

### その他
- `.mcp.json`: shadcn MCP の登録

## Test plan

- [ ] `npm run dev` で起動し `/dashboard` の KPI がロード時にカウントアップする
- [ ] `/dashboard` の期間/媒体フィルタを変更すると KPI が再度アニメする
- [ ] `/dashboard` 媒体別カードに予算消化 Meter が表示される（サンプルデータで色が 80/100% で切り替わる）
- [ ] `/budget` の 3 箇所の Meter（総・媒体別・キャンペーン行）が表示される
- [ ] `/campaigns` `/keywords` `/ads` `/creatives` `/search-terms` でフィルター条件を変えて 0 件状態にし、空状態 UI が出る
- [ ] モバイル幅（375px）でレイアウトが崩れない
- [ ] `prefers-reduced-motion: reduce` でアニメが無効化される
- [ ] Lint / Type check が通る（`npx tsc --noEmit`）

## 残タスク

別 PR で対応:
- #15 Skeleton 遷移
- #16 ステータス Chip 統一
- #17 ProgressCircle KPI
- #19 ページ遷移フェードイン
- #20 Sonner 統一
- #21 Sidebar アニメ
- #22 Tooltip motion
- #23 ファネルグラフ再設計

🤖 Generated with [Claude Code](https://claude.com/claude-code)