### PR TITLE
feat(layout): サイドバーを sticky で画面左に固定 (#25)

### DIFF
--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -45,9 +45,9 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <SidebarContext.Provider value={{ collapsed, setCollapsed, ready }}>
-      <div className="flex min-h-screen bg-slate-50">
+      <div className="flex min-h-screen items-start bg-slate-50">
         <Sidebar />
-        <main className="flex-1 overflow-auto">
+        <main className="flex-1 min-w-0">
           <div className="p-6">{children}</div>
         </main>
         <Toaster richColors position="top-right" />

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -128,7 +128,7 @@ export function Sidebar() {
   return (
     <aside
       className={cn(
-        'min-h-screen bg-sidebar text-sidebar-foreground flex flex-col overflow-hidden',
+        'sticky top-0 h-screen shrink-0 bg-sidebar text-sidebar-foreground flex flex-col overflow-hidden',
         collapsed ? 'w-16' : 'w-60',
         animate && 'transition-[width] duration-300 ease-in-out',
       )}


### PR DESCRIPTION
## Summary
- Sidebar の `aside` を `sticky top-0 h-screen` にして、本文をスクロールしても左側のメニューが常に viewport に固定されるように
- メニュー項目が viewport 高を超える場合はサイドバー内だけ `overflow-y-auto` でスクロール
- `main` の `overflow-auto` を外して window スクロールと sticky が正しく連動するように修正（`items-start` + `min-w-0` でレイアウト破綻を防止）

## Related
Closes #25

## Test plan
- [ ] `/campaigns` など縦長ページで下にスクロールしてもサイドバーが残ること
- [ ] サイドバー折りたたみ状態（w-16）でも sticky が機能すること
- [ ] メニュー項目増加時にサイドバー内部だけスクロールし、ヘッダーロゴ/媒体接続ブロックは見切れないこと
- [ ] モバイル幅でレイアウトが崩れないこと
- [ ] Toaster（右上通知）と干渉しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)