### PR TITLE
feat(ui): ステータス表示を HeroUI Chip に統一 (#16)

### DIFF
--- a/app/ad-groups/page.tsx
+++ b/app/ad-groups/page.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon } from 'lucide-react';
+import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import {
   AD_GROUPS,
@@ -266,16 +267,9 @@ export default function AdGroupsListPage() {
 
                   return (
                     <TableRow key={ag.id} className="text-sm">
-                      {/* ステータスドット */}
+                      {/* ステータス */}
                       <TableCell className="pl-4">
-                        <span
-                          className={cn(
-                            'inline-block h-2 w-2 rounded-full',
-                            ag.status === 'active' ? 'bg-green-500' : 'bg-gray-400',
-                          )}
-                          title={ag.status === 'active' ? '有効' : '一時停止'}
-                          aria-label={`ステータス: ${ag.status === 'active' ? '有効' : '一時停止'}`}
-                        />
+                        <StatusChip status={ag.status} />
                       </TableCell>
 
                       {/* 広告グループ名（ドリルダウンリンク） */}

--- a/app/ads/page.tsx
+++ b/app/ads/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
+import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import {
   ADS,
@@ -277,16 +278,9 @@ export default function AdsListPage() {
 
                   return (
                     <TableRow key={ad.id} className="text-sm">
-                      {/* ステータスドット */}
+                      {/* ステータス */}
                       <TableCell className="pl-4">
-                        <span
-                          className={cn(
-                            'inline-block h-2 w-2 rounded-full',
-                            ad.status === 'active' ? 'bg-green-500' : 'bg-gray-400',
-                          )}
-                          title={ad.status === 'active' ? '有効' : '一時停止'}
-                          aria-label={`ステータス: ${ad.status === 'active' ? '有効' : '一時停止'}`}
-                        />
+                        <StatusChip status={ad.status} />
                       </TableCell>
 
                       {/* 広告名 */}

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/table'
 import { InfoIcon, CheckIcon, XIcon } from 'lucide-react'
 import { Meter } from '@heroui/react'
+import { StatusChip } from '@/components/ui/status-chip'
 
 const fmt = (n: number) =>
   new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY', maximumFractionDigits: 0 }).format(n)
@@ -49,10 +50,10 @@ const AD_TYPE_LABELS: Record<string, string> = {
   display: 'ディスプレイ',
 }
 
-const STATUS_LABELS: Record<string, { label: string; variant: 'success' | 'warning' | 'outline' | 'secondary' }> = {
-  active: { label: '配信中', variant: 'success' },
-  paused: { label: '停止中', variant: 'warning' },
-  ended: { label: '終了', variant: 'secondary' },
+const STATUS_LABELS: Record<string, string> = {
+  active: '配信中',
+  paused: '停止中',
+  ended: '終了',
 }
 
 const MOCK_CAMPAIGNS: CampaignBudget[] = [
@@ -304,7 +305,7 @@ export default function BudgetPage() {
                 </TableHeader>
                 <TableBody>
                   {campaigns.map((c) => {
-                    const st = STATUS_LABELS[c.status] ?? { label: c.status, variant: 'outline' as const }
+                    const statusLabel = STATUS_LABELS[c.status] ?? c.status
                     return (
                       <TableRow key={c.id}>
                         <TableCell className="font-medium max-w-[200px] truncate" title={c.name}>
@@ -382,7 +383,7 @@ export default function BudgetPage() {
                           </div>
                         </TableCell>
                         <TableCell>
-                          <Badge variant={st.variant}>{st.label}</Badge>
+                          <StatusChip status={c.status} label={statusLabel} />
                         </TableCell>
                       </TableRow>
                     )

--- a/app/campaigns/[id]/[adGroupId]/page.tsx
+++ b/app/campaigns/[id]/[adGroupId]/page.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { InfoIcon, ImageIcon } from 'lucide-react';
+import { StatusChip, StatusDot } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import {
   getCampaign,
@@ -85,10 +86,7 @@ function SearchAdsTable({ ads }: { ads: AdData[] }) {
             {ads.map((ad) => (
               <TableRow key={ad.id} className="text-sm">
                 <TableCell className="pl-4">
-                  <span
-                    className={cn('inline-block h-2 w-2 rounded-full', ad.status === 'active' ? 'bg-green-500' : 'bg-gray-400')}
-                    aria-label={`ステータス: ${ad.status === 'active' ? '有効' : '一時停止'}`}
-                  />
+                  <StatusChip status={ad.status} />
                 </TableCell>
                 <TableCell>
                   <div className="space-y-0.5">
@@ -141,12 +139,9 @@ function CreativeGallery({ ads }: { ads: AdData[] }) {
             </div>
           </div>
           <CardContent className="p-3 space-y-2">
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-2">
               <p className="text-sm font-medium truncate" title={ad.name}>{ad.name}</p>
-              <span className={cn(
-                'inline-block h-2 w-2 rounded-full shrink-0 ml-2',
-                ad.status === 'active' ? 'bg-green-500' : 'bg-gray-400',
-              )} aria-label={`ステータス: ${ad.status === 'active' ? '有効' : '一時停止'}`} />
+              <StatusDot status={ad.status} className="ml-2" />
             </div>
             <div className="grid grid-cols-3 gap-2 text-center">
               <div>
@@ -209,10 +204,7 @@ function DisplayAdsTable({ ads }: { ads: AdData[] }) {
             {ads.map((ad) => (
               <TableRow key={ad.id} className="text-sm">
                 <TableCell className="pl-4">
-                  <span
-                    className={cn('inline-block h-2 w-2 rounded-full', ad.status === 'active' ? 'bg-green-500' : 'bg-gray-400')}
-                    aria-label={`ステータス: ${ad.status === 'active' ? '有効' : '一時停止'}`}
-                  />
+                  <StatusChip status={ad.status} />
                 </TableCell>
                 <TableCell className="font-medium">
                   <div className="truncate max-w-xs" title={ad.name}>{ad.name}</div>
@@ -272,13 +264,7 @@ function KeywordsTable({ keywords }: { keywords: KeywordData[] }) {
               return (
                 <TableRow key={kw.id} className="text-sm">
                   <TableCell className="pl-4">
-                    <span
-                      className={cn(
-                        'inline-block h-2 w-2 rounded-full',
-                        kw.status === 'active' ? 'bg-green-500' : kw.status === 'limited' ? 'bg-yellow-400' : 'bg-gray-400',
-                      )}
-                      aria-label={`ステータス: ${kw.status}`}
-                    />
+                    <StatusChip status={kw.status} />
                   </TableCell>
                   <TableCell className="font-medium">{kw.keyword}</TableCell>
                   <TableCell>

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon } from 'lucide-react';
+import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import {
   getCampaign,
@@ -224,16 +225,9 @@ export default function AdGroupsPage({
               <TableBody>
                 {sorted.map((ag) => (
                   <TableRow key={ag.id} className="text-sm">
-                    {/* ステータスドット */}
+                    {/* ステータス */}
                     <TableCell className="pl-4">
-                      <span
-                        className={cn(
-                          'inline-block h-2 w-2 rounded-full',
-                          ag.status === 'active' ? 'bg-green-500' : 'bg-gray-400',
-                        )}
-                        title={ag.status === 'active' ? '有効' : '一時停止'}
-                        aria-label={`ステータス: ${ag.status === 'active' ? '有効' : '一時停止'}`}
-                      />
+                      <StatusChip status={ag.status} />
                     </TableCell>
 
                     {/* 広告グループ名（ドリルダウンリンク） */}

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -22,8 +22,9 @@ import {
 } from '@/components/ui/select';
 import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
+import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
-import { CAMPAIGNS, type CampaignData, type CampaignStatus, type Platform, type AdType } from '@/lib/campaign-mock-data';
+import { CAMPAIGNS, type CampaignData, type Platform, type AdType } from '@/lib/campaign-mock-data';
 
 // ─── 定数 ──────────────────────────────────────────────────────
 
@@ -38,13 +39,6 @@ type SortKey =
   | 'cpc'
   | 'conversions'
   | 'cpa';
-
-const STATUS_CONFIG: Record<CampaignStatus, { label: string; dot: string }> = {
-  active:         { label: '有効',          dot: 'bg-green-500' },
-  active_limited: { label: '有効（制限付き）', dot: 'bg-yellow-400' },
-  paused:         { label: '一時停止',       dot: 'bg-gray-400' },
-  ended:          { label: '終了',           dot: 'bg-gray-300' },
-};
 
 const PLATFORM_CONFIG: Record<Platform, { label: string; className: string }> = {
   google: { label: 'Google',  className: 'bg-blue-100 text-blue-700' },
@@ -282,18 +276,13 @@ export default function CampaignsPage() {
 
               <TableBody>
                 {filtered.map((c) => {
-                  const { dot, label: statusLabel } = STATUS_CONFIG[c.status];
                   const { label: platformLabel, className: platformClass } = PLATFORM_CONFIG[c.platform];
 
                   return (
                     <TableRow key={c.id} className="text-sm">
-                      {/* ステータスドット */}
+                      {/* ステータス */}
                       <TableCell className="pl-4">
-                        <span
-                          className={cn('inline-block h-2 w-2 rounded-full', dot)}
-                          title={statusLabel}
-                          aria-label={`ステータス: ${statusLabel}`}
-                        />
+                        <StatusChip status={c.status} />
                       </TableCell>
 
                       {/* キャンペーン名（ドリルダウンリンク） */}
@@ -304,7 +293,6 @@ export default function CampaignsPage() {
                         >
                           <div className="truncate" title={c.name}>{c.name}</div>
                         </Link>
-                        <div className="text-xs text-muted-foreground">{statusLabel}</div>
                       </TableCell>
 
                       {/* 媒体 */}

--- a/app/creatives/page.tsx
+++ b/app/creatives/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dialog'
 import { PlusIcon, PauseIcon, PlayIcon, Trash2Icon, InfoIcon, SearchXIcon } from 'lucide-react'
 import { EmptyState } from '@/components/ui/empty-state'
+import { StatusChip } from '@/components/ui/status-chip'
 
 interface Creative {
   id: string
@@ -50,11 +51,6 @@ const PLATFORM_COLORS: Record<string, string> = {
 }
 const PLATFORM_LABELS: Record<string, string> = { google: 'Google', yahoo: 'Yahoo!', bing: 'Bing' }
 const STATUS_LABELS: Record<string, string> = { active: '配信中', paused: '停止中', removed: '削除済' }
-const STATUS_VARIANTS: Record<string, 'success' | 'warning' | 'secondary'> = {
-  active: 'success',
-  paused: 'warning',
-  removed: 'secondary',
-}
 
 const MOCK_CREATIVES: Creative[] = [
   { id: 'mc1', name: '春季キャンペーン メインバナー', type: 'responsive', status: 'active', headline1: '春の特大セール開催中', headline2: '最大50%OFF！今すぐチェック', headline3: '期間限定・数量限定', description1: '春の新生活を応援。人気商品が大幅値引き。', description2: '送料無料キャンペーン実施中！', adGroup: { id: 'ag1', name: '春季グループ', campaign: { platform: 'google', name: 'ブランド訴求' } } },
@@ -240,7 +236,6 @@ export default function CreativesPage() {
             ? [0, 1, 2, 3, 4, 5].map((i) => <CreativeSkeleton key={i} />)
             : creatives.map((c) => {
                 const platform = c.adGroup?.campaign?.platform ?? ''
-                const sv = STATUS_VARIANTS[c.status] ?? 'outline'
                 return (
                   <Card key={c.id} className="flex flex-col">
                     <CardHeader className="pb-2">
@@ -261,9 +256,7 @@ export default function CreativesPage() {
                           <Badge variant={TYPE_VARIANTS[c.type] ?? 'secondary'} className="text-xs">
                             {TYPE_LABELS[c.type] ?? c.type}
                           </Badge>
-                          <Badge variant={sv} className="text-xs">
-                            {STATUS_LABELS[c.status] ?? c.status}
-                          </Badge>
+                          <StatusChip status={c.status} label={STATUS_LABELS[c.status] ?? c.status} />
                         </div>
                       </div>
                       {c.adGroup && (

--- a/app/keywords/page.tsx
+++ b/app/keywords/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { ChevronUp, ChevronDown, ChevronsUpDown, InfoIcon, SearchXIcon } from 'lucide-react';
 import { EmptyState } from '@/components/ui/empty-state';
+import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import {
   KEYWORDS,
@@ -277,15 +278,9 @@ export default function KeywordsListPage() {
 
                   return (
                     <TableRow key={kw.id} className="text-sm">
-                      {/* ステータスドット */}
+                      {/* ステータス */}
                       <TableCell className="pl-4">
-                        <span
-                          className={cn(
-                            'inline-block h-2 w-2 rounded-full',
-                            kw.status === 'active' ? 'bg-green-500' : kw.status === 'limited' ? 'bg-yellow-400' : 'bg-gray-400',
-                          )}
-                          aria-label={`ステータス: ${kw.status}`}
-                        />
+                        <StatusChip status={kw.status} />
                       </TableCell>
 
                       {/* キーワード */}

--- a/components/ui/status-chip.tsx
+++ b/components/ui/status-chip.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+import { Chip } from '@heroui/react';
+import { getStatusTone } from '@/lib/status';
+import { cn } from '@/lib/utils';
+
+export interface StatusChipProps {
+  status: string;
+  /** 表示ラベルを上書き（省略時は lib/status.ts のデフォルト文言） */
+  label?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export function StatusChip({ status, label, size = 'sm', className }: StatusChipProps) {
+  const tone = getStatusTone(status);
+  return (
+    <Chip size={size} variant="soft" color={tone.color} className={cn('gap-1.5', className)}>
+      <span
+        className={cn('inline-block w-1.5 h-1.5 rounded-full shrink-0', tone.dotClass)}
+        aria-hidden="true"
+      />
+      <Chip.Label>{label ?? tone.defaultLabel}</Chip.Label>
+    </Chip>
+  );
+}
+
+/**
+ * テーブル先頭セルなど、ラベルを省いてドットだけ出したい場合に使う。
+ * aria-label は内部で自動付与する。
+ */
+export function StatusDot({
+  status,
+  label,
+  className,
+}: Pick<StatusChipProps, 'status' | 'label' | 'className'>) {
+  const tone = getStatusTone(status);
+  const title = label ?? tone.defaultLabel;
+  return (
+    <span
+      className={cn('inline-block h-2 w-2 rounded-full shrink-0', tone.dotClass, className)}
+      title={title}
+      aria-label={`ステータス: ${title}`}
+    />
+  );
+}

--- a/lib/status.ts
+++ b/lib/status.ts
@@ -1,0 +1,35 @@
+/**
+ * 広告プラットフォームにおけるステータス表示の色・ラベル定義を一元管理する。
+ * キャンペーン / 広告グループ / 広告 / キーワード / クリエイティブ / 予算 で共通利用する。
+ */
+
+export type CommonStatus =
+  | 'active'
+  | 'active_limited'
+  | 'limited'
+  | 'paused'
+  | 'ended'
+  | 'removed';
+
+export type StatusChipColor = 'success' | 'warning' | 'default';
+
+export type StatusTone = {
+  color: StatusChipColor;
+  /** Chip 左端のインジケータードット（HeroUI の色とは別に明度を揃えた Tailwind クラス） */
+  dotClass: string;
+  /** ラベル省略時のデフォルト文言 */
+  defaultLabel: string;
+};
+
+const STATUS_TONE: Record<CommonStatus, StatusTone> = {
+  active:         { color: 'success', dotClass: 'bg-green-500',  defaultLabel: '有効' },
+  active_limited: { color: 'warning', dotClass: 'bg-yellow-400', defaultLabel: '有効（制限付き）' },
+  limited:        { color: 'warning', dotClass: 'bg-yellow-400', defaultLabel: '制限付き' },
+  paused:         { color: 'warning', dotClass: 'bg-amber-400',  defaultLabel: '一時停止' },
+  ended:          { color: 'default', dotClass: 'bg-gray-300',   defaultLabel: '終了' },
+  removed:        { color: 'default', dotClass: 'bg-gray-400',   defaultLabel: '削除済' },
+};
+
+export function getStatusTone(status: string): StatusTone {
+  return STATUS_TONE[status as CommonStatus] ?? STATUS_TONE.paused;
+}


### PR DESCRIPTION
## Summary
- `lib/status.ts` に共通ステータス定義（色・ドット・デフォルトラベル）を集約
- `components/ui/status-chip.tsx` に `StatusChip`（HeroUI Chip + ドット）と `StatusDot`（ドットのみ）を追加
- 次のページのステータス表示を置換:
  - `/campaigns`, `/campaigns/[id]`, `/campaigns/[id]/[adGroupId]`（検索・ディスプレイ・キーワード）
  - `/ad-groups`, `/ads`, `/keywords`
  - `/creatives`（カードヘッダ Badge → Chip）
  - `/budget`（テーブル Badge → Chip）
- 色ルール: `有効=success` / `制限付き・一時停止=warning` / `終了・削除=default`

## Related
Closes #16

## Test plan
- [ ] 各一覧ページでステータスが Chip（ドット+ラベル）として表示される
- [ ] 有効は緑、一時停止・制限付きは黄、削除済・終了はグレーで表示される
- [ ] キャンペーン詳細内のタブ（検索広告・ディスプレイ広告・キーワード）でも同じ Chip になる
- [ ] クリエイティブカードの「ステータス」Badge が Chip に置き換わり、タイプ Badge とは並列に表示される
- [ ] 予算管理テーブルのステータス列が Chip 表示になる
- [ ] 既存のフィルタ（ステータスプルダウン）が引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)