### PR TITLE
feat: ページ遷移フェードイン（motion/react）

### DIFF
--- a/app/ad-groups/page.tsx
+++ b/app/ad-groups/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Table,
@@ -178,7 +177,6 @@ export default function AdGroupsListPage() {
   }, [filtered]);
 
   return (
-    <MainLayout>
       <div className="space-y-4">
         {/* ヘッダー */}
         <div>
@@ -376,6 +374,5 @@ export default function AdGroupsListPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   );
 }

--- a/app/ads/page.tsx
+++ b/app/ads/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Table,
@@ -193,7 +192,6 @@ export default function AdsListPage() {
   }, [filtered]);
 
   return (
-    <MainLayout>
       <div className="space-y-4">
         {/* ヘッダー */}
         <div>
@@ -387,6 +385,5 @@ export default function AdsListPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   );
 }

--- a/app/ai-advisor/page.tsx
+++ b/app/ai-advisor/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -107,7 +106,6 @@ export default function AiAdvisorPage() {
   }
 
   return (
-    <MainLayout>
       <div className="space-y-6">
         {/* Header */}
         <div className="flex items-center gap-3">
@@ -287,6 +285,5 @@ export default function AiAdvisorPage() {
           </div>
         </div>
       </div>
-    </MainLayout>
   )
 }

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useRef } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -169,7 +168,6 @@ export default function BudgetPage() {
     u > 100 ? 'destructive' : u > 80 ? 'warning' : 'success'
 
   return (
-    <MainLayout>
       <div className="space-y-6">
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -394,6 +392,5 @@ export default function BudgetPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   )
 }

--- a/app/campaigns/[id]/[adGroupId]/page.tsx
+++ b/app/campaigns/[id]/[adGroupId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Breadcrumb,
@@ -311,9 +310,7 @@ export default function AdGroupDetailPage({
 
   if (!campaign || !adGroup) {
     return (
-      <MainLayout>
         <div className="p-8 text-center text-muted-foreground">広告グループが見つかりません</div>
-      </MainLayout>
     );
   }
 
@@ -322,7 +319,6 @@ export default function AdGroupDetailPage({
   const platformCfg = PLATFORM_CONFIG[campaign.platform];
 
   return (
-    <MainLayout>
       <div className="space-y-4">
         {/* パンくず */}
         <Breadcrumb>
@@ -428,6 +424,5 @@ export default function AdGroupDetailPage({
           )}
         </Tabs>
       </div>
-    </MainLayout>
   );
 }

--- a/app/campaigns/[id]/loading.tsx
+++ b/app/campaigns/[id]/loading.tsx
@@ -1,4 +1,3 @@
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -15,7 +14,6 @@ const BODY_ROWS = 8;
 
 export default function Loading() {
   return (
-    <MainLayout>
       <div
         className="space-y-4"
         role="status"
@@ -97,6 +95,5 @@ export default function Loading() {
 
         <span className="sr-only">読み込み中…</span>
       </div>
-    </MainLayout>
   );
 }

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Breadcrumb,
@@ -146,16 +145,13 @@ export default function AdGroupsPage({
 
   if (!campaign) {
     return (
-      <MainLayout>
         <div className="p-8 text-center text-muted-foreground">キャンペーンが見つかりません</div>
-      </MainLayout>
     );
   }
 
   const platformCfg = PLATFORM_CONFIG[campaign.platform];
 
   return (
-    <MainLayout>
       <div className="space-y-4">
         {/* パンくず */}
         <Breadcrumb>
@@ -342,6 +338,5 @@ export default function AdGroupsPage({
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   );
 }

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Table,
@@ -162,7 +161,7 @@ export default function CampaignsPage() {
   }, [filtered]);
 
   return (
-    <MainLayout>
+    <>
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:p-2">
         メインコンテンツへスキップ
       </a>
@@ -397,6 +396,6 @@ export default function CampaignsPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
+    </>
   );
 }

--- a/app/creatives/page.tsx
+++ b/app/creatives/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -182,7 +181,7 @@ export default function CreativesPage() {
   }
 
   return (
-    <MainLayout>
+    <>
       <div className="space-y-6">
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -414,6 +413,6 @@ export default function CreativesPage() {
           <DialogClose onClick={() => setNewDialogOpen(false)} />
         </DialogContent>
       </Dialog>
-    </MainLayout>
+    </>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -646,7 +645,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <MainLayout>
+    <>
       <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:p-2">
         メインコンテンツへスキップ
       </a>
@@ -1146,6 +1145,6 @@ export default function DashboardPage() {
           </div>
         )}
       </div>
-    </MainLayout>
+    </>
   );
 }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -138,7 +137,6 @@ export default function HistoryPage() {
   }, [fetchData])
 
   return (
-    <MainLayout>
       <div className="space-y-6">
         {/* Header */}
         <div>
@@ -308,6 +306,5 @@ export default function HistoryPage() {
           </div>
         )}
       </div>
-    </MainLayout>
   )
 }

--- a/app/keywords/page.tsx
+++ b/app/keywords/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { MainLayout } from '@/components/layout/MainLayout';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   Table,
@@ -205,7 +204,6 @@ export default function KeywordsListPage() {
   }, [filtered]);
 
   return (
-    <MainLayout>
       <div className="space-y-4">
         {/* ヘッダー */}
         <div>
@@ -395,6 +393,5 @@ export default function KeywordsListPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { MainLayout } from '@/components/layout/MainLayout';
 
 const inter = Inter({ subsets: ['latin'], weight: ['400', '500', '700'] });
 
@@ -16,7 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" className="h-full">
-      <body className={`${inter.className} min-h-full`}>{children}</body>
+      <body className={`${inter.className} min-h-full`}>
+        <MainLayout>{children}</MainLayout>
+      </body>
     </html>
   );
 }

--- a/app/search-terms/page.tsx
+++ b/app/search-terms/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -152,7 +151,6 @@ export default function SearchTermsPage() {
   )
 
   return (
-    <MainLayout>
       <div className="space-y-6">
         {/* Header */}
         <div>
@@ -285,6 +283,5 @@ export default function SearchTermsPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   )
 }

--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { MainLayout } from '@/components/layout/MainLayout'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -133,7 +132,6 @@ export default function SyncPage() {
   })
 
   return (
-    <MainLayout>
       <div className="space-y-6">
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -256,6 +254,5 @@ export default function SyncPage() {
           </CardContent>
         </Card>
       </div>
-    </MainLayout>
   )
 }

--- a/components/animate-ui/page-transition.tsx
+++ b/components/animate-ui/page-transition.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as React from 'react';
+import { usePathname } from 'next/navigation';
+import { motion, useReducedMotion } from 'motion/react';
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion();
+
+  if (reduceMotion) {
+    return <>{children}</>;
+  }
+
+  return (
+    <motion.div
+      key={pathname}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { Sidebar } from './Sidebar';
 import { Toaster } from 'sonner';
+import { PageTransition } from '@/components/animate-ui/page-transition';
 
 type SidebarContextValue = {
   collapsed: boolean;
@@ -48,7 +49,9 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
       <div className="flex min-h-screen items-start bg-slate-50">
         <Sidebar />
         <main className="flex-1 min-w-0">
-          <div className="p-6">{children}</div>
+          <div className="p-6">
+            <PageTransition>{children}</PageTransition>
+          </div>
         </main>
         <Toaster richColors position="top-right" />
       </div>


### PR DESCRIPTION
## Summary
- MainLayout を `app/layout.tsx` の共通レイアウトに昇格し、14ページの `<MainLayout>` ラップを削除
- `components/animate-ui/page-transition.tsx` を追加: pathname 変化で motion.div を再マウントし、opacity 0→1 + y 12px→0（280ms, easeOutCubic）でふわっと表示
- `prefers-reduced-motion` はアニメーション無効

## Related
- Closes #19

## Test plan
- [ ] サイドバーから各ページを遷移するたびにコンテンツがフェードインする
- [ ] OSの「視差効果を減らす」ON時はアニメーションが走らない
- [ ] 型チェック（\`tsc --noEmit\`）が通る
- [ ] ダッシュボード / キャンペーン / クリエイティブなど複雑ページも表示崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)