### PR TITLE
fix: キャンペーン/ダッシュボードのスキップリンクを削除

### DIFF
--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -161,12 +161,7 @@ export default function CampaignsPage() {
   }, [filtered]);
 
   return (
-    <>
-      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:p-2">
-        メインコンテンツへスキップ
-      </a>
-
-      <div id="main-content" className="space-y-4">
+      <div className="space-y-4">
         {/* ページヘッダー */}
         <div className="flex items-start justify-between">
           <div>
@@ -396,6 +391,5 @@ export default function CampaignsPage() {
           </CardContent>
         </Card>
       </div>
-    </>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -645,11 +645,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <>
-      <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:p-2">
-        メインコンテンツへスキップ
-      </a>
-      <div id="main-content" className="space-y-6">
+      <div className="space-y-6">
 
         {/* ─── ヘッダー ─── */}
         <div className="flex flex-wrap items-center gap-3">
@@ -1145,6 +1141,5 @@ export default function DashboardPage() {
           </div>
         )}
       </div>
-    </>
   );
 }


### PR DESCRIPTION
## Summary
- Next.js App Router のナビゲーション後オートフォーカス挙動により、\`sr-only focus:not-sr-only focus:absolute\` なスキップリンクがページ遷移直後に可視化され、h1タイトルと重なる問題が発生
- スキップリンクは2ページ（キャンペーン/ダッシュボード）だけに残っていた中途半端な実装だったため一旦撤去
- 将来 a11y 整備時に全ページ統一して導入する想定

## Test plan
- [ ] ダッシュボード/キャンペーンを開いた時にタイトルのみ表示される（他の文字と被らない）
- [ ] 他ページの表示は変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)