### PR TITLE
feat(ui): Sonner トースト通知を notify ヘルパーで統一

### DIFF
--- a/app/ai-advisor/page.tsx
+++ b/app/ai-advisor/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -70,7 +70,7 @@ export default function AiAdvisorPage() {
         const insData = await insRes.json()
         setInsights(Array.isArray(insData) ? insData : [])
       } catch {
-        toast.error('インサイトの取得に失敗しました')
+        notify.error('インサイトの取得に失敗しました')
       } finally {
         setLoading(false)
       }
@@ -87,7 +87,7 @@ export default function AiAdvisorPage() {
     if (!content) return
     setMessages((m) => [...m, { role: 'user', content }])
     setChatInput('')
-    toast.error('Claude API未連携のため、現在使用できません')
+    notify.error('Claude API未連携のため、現在使用できません')
     setTimeout(() => {
       setMessages((m) => [
         ...m,

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -101,7 +101,7 @@ export default function BudgetPage() {
         setIsMock(true)
       }
     } catch {
-      toast.error('データの取得に失敗しました')
+      notify.error('データの取得に失敗しました')
       setCampaigns(MOCK_CAMPAIGNS)
       setIsMock(true)
     } finally {
@@ -143,7 +143,7 @@ export default function BudgetPage() {
   const saveEdit = async (id: string) => {
     const val = parseFloat(editValue)
     if (isNaN(val) || val < 0) {
-      toast.error('有効な金額を入力してください')
+      notify.error('有効な金額を入力してください')
       return
     }
     try {
@@ -153,11 +153,11 @@ export default function BudgetPage() {
         body: JSON.stringify({ monthlyBudget: val }),
       })
       if (!res.ok) throw new Error()
-      toast.success('予算を更新しました')
+      notify.success('予算を更新しました')
       cancelEdit()
       fetchData(month)
     } catch {
-      toast.error('予算の更新に失敗しました')
+      notify.error('予算の更新に失敗しました')
     }
   }
 

--- a/app/creatives/page.tsx
+++ b/app/creatives/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -115,7 +115,7 @@ export default function CreativesPage() {
         setIsMock(true)
       }
     } catch {
-      toast.error('データの取得に失敗しました')
+      notify.error('データの取得に失敗しました')
       setCreatives(MOCK_CREATIVES)
       setIsMock(true)
     } finally {
@@ -136,10 +136,10 @@ export default function CreativesPage() {
         body: JSON.stringify({ status: newStatus }),
       })
       if (!res.ok) throw new Error()
-      toast.success(newStatus === 'active' ? '配信を再開しました' : '配信を停止しました')
+      notify.success(newStatus === 'active' ? '配信を再開しました' : '配信を停止しました')
       fetchData()
     } catch {
-      toast.error('ステータスの変更に失敗しました')
+      notify.error('ステータスの変更に失敗しました')
     }
   }
 
@@ -148,17 +148,17 @@ export default function CreativesPage() {
     try {
       const res = await fetch(`/api/creatives/${deleteId}`, { method: 'DELETE' })
       if (!res.ok) throw new Error()
-      toast.success('クリエイティブを削除しました')
+      notify.success('クリエイティブを削除しました')
       setDeleteId(null)
       fetchData()
     } catch {
-      toast.error('削除に失敗しました')
+      notify.error('削除に失敗しました')
     }
   }
 
   const handleCreate = async () => {
     if (!form.name || !form.adGroupId) {
-      toast.error('名前と広告グループIDは必須です')
+      notify.error('名前と広告グループIDは必須です')
       return
     }
     setSubmitting(true)
@@ -169,12 +169,12 @@ export default function CreativesPage() {
         body: JSON.stringify(form),
       })
       if (!res.ok) throw new Error()
-      toast.success('クリエイティブを作成しました')
+      notify.success('クリエイティブを作成しました')
       setNewDialogOpen(false)
       setForm({ name: '', type: 'text', adGroupId: '', headline1: '', headline2: '', headline3: '', description1: '', description2: '' })
       fetchData()
     } catch {
-      toast.error('作成に失敗しました')
+      notify.error('作成に失敗しました')
     } finally {
       setSubmitting(false)
     }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -124,7 +124,7 @@ export default function HistoryPage() {
         setIsMock(true)
       }
     } catch {
-      toast.error('データの取得に失敗しました')
+      notify.error('データの取得に失敗しました')
       setHistories(MOCK_HISTORIES)
       setIsMock(true)
     } finally {

--- a/app/search-terms/page.tsx
+++ b/app/search-terms/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -95,7 +95,7 @@ export default function SearchTermsPage() {
         setIsMock(true)
       }
     } catch {
-      toast.error('データの取得に失敗しました')
+      notify.error('データの取得に失敗しました')
       setTerms(MOCK_TERMS)
       setIsMock(true)
     } finally {
@@ -125,10 +125,10 @@ export default function SearchTermsPage() {
         body: JSON.stringify({ isExcluded: newVal }),
       })
       if (!res.ok) throw new Error()
-      toast.success(newVal ? '除外候補に設定しました' : '除外を解除しました')
+      notify.success(newVal ? '除外候補に設定しました' : '除外を解除しました')
       fetchData()
     } catch {
-      toast.error('更新に失敗しました')
+      notify.error('更新に失敗しました')
     }
   }
 

--- a/app/sync/page.tsx
+++ b/app/sync/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import { notify } from '@/lib/toast'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -81,7 +81,7 @@ export default function SyncPage() {
         setIsMock(true)
       }
     } catch {
-      toast.error('ログの取得に失敗しました')
+      notify.error('ログの取得に失敗しました')
       setLogs(MOCK_LOGS)
       setIsMock(true)
     } finally {
@@ -102,14 +102,14 @@ export default function SyncPage() {
         body: JSON.stringify({ platform }),
       })
       if (!res.ok) throw new Error()
-      toast.success(`${PLATFORM_LABELS[platform]} の同期を開始しました`)
+      notify.success(`${PLATFORM_LABELS[platform]} の同期を開始しました`)
       // Refresh after 4 seconds to show updated status
       setTimeout(() => {
         fetchLogs()
         setSyncing((s) => ({ ...s, [platform]: false }))
       }, 4000)
     } catch {
-      toast.error('同期の開始に失敗しました')
+      notify.error('同期の開始に失敗しました')
       setSyncing((s) => ({ ...s, [platform]: false }))
     }
   }

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -53,7 +53,13 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
             <PageTransition>{children}</PageTransition>
           </div>
         </main>
-        <Toaster richColors position="top-right" />
+        <Toaster
+          richColors
+          closeButton
+          position="top-right"
+          duration={4000}
+          toastOptions={{ classNames: { toast: 'rounded-lg' } }}
+        />
       </div>
     </SidebarContext.Provider>
   );

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,18 @@
+import { toast, type ExternalToast } from 'sonner';
+
+/**
+ * プロジェクト全体で統一された通知API。
+ * severity は success / error / warning / info の4種類。
+ *
+ * sonner の `richColors` と組み合わせることで、severity ごとに
+ * 左端のアイコン＋色付き背景が自動で付与される。
+ */
+export const notify = {
+  success: (message: string, options?: ExternalToast) => toast.success(message, options),
+  error: (message: string, options?: ExternalToast) => toast.error(message, options),
+  warning: (message: string, options?: ExternalToast) => toast.warning(message, options),
+  info: (message: string, options?: ExternalToast) => toast.info(message, options),
+  /** 確認ダイアログ風（アクション付き）。戻す系オペレーションに使う */
+  action: (message: string, action: { label: string; onClick: () => void }, options?: ExternalToast) =>
+    toast(message, { ...options, action }),
+};


### PR DESCRIPTION
## Summary
- \`lib/toast.ts\` に \`notify.success/error/warning/info/action\` を集約し severity を4種に統一
- \`MainLayout\` の Toaster に \`closeButton\` / \`duration=4000\` / 角丸 toastOptions を追加
- 6ページ（budget / search-terms / ai-advisor / creatives / sync / history）の直接 \`toast.*\` 呼び出しを \`notify.*\` に置換（21箇所）

## Related
- Closes #20

## Test plan
- [ ] 予算更新成功時に success トースト（緑＋チェックアイコン）
- [ ] データ取得失敗時に error トースト（赤＋×アイコン）
- [ ] クローズボタンが各トーストに表示される
- [ ] 位置・スタイルが全ページで統一される

🤖 Generated with [Claude Code](https://claude.com/claude-code)