### PR TITLE
fix(ui): カウントアップアニメーションをスナッピーに

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -383,7 +383,7 @@ function KpiCard({
                   number={rawValue}
                   format={format}
                   decimalPlaces={decimalPlaces ?? 0}
-                  transition={{ stiffness: 120, damping: 30 }}
+                  transition={{ stiffness: 260, damping: 32 }}
                 />
               ) : (
                 value ?? fallback ?? '—'

--- a/components/dashboard/funnel-flow.tsx
+++ b/components/dashboard/funnel-flow.tsx
@@ -217,7 +217,7 @@ function FunnelColumn({
           <p className="text-lg sm:text-2xl font-bold tabular-nums tracking-tight mt-0.5 leading-tight">
             <CountingNumber
               number={stage.value}
-              transition={{ stiffness: 120, damping: 30 }}
+              transition={{ stiffness: 260, damping: 32 }}
               delay={delay}
               format={(v) => numFormat.format(Math.round(v))}
             />


### PR DESCRIPTION
## Summary
- 数値カウントアップの spring を `stiffness 120 → 260`, `damping 30 → 32` に調整
- 表示数など桁が大きい KPI で「長い」と感じられていたのを短時間で収束するように変更

## 修正箇所
- `app/dashboard/page.tsx` (KpiCard: 総費用/CV数/CPA/CVR)
- `components/dashboard/funnel-flow.tsx` (ファネル: 表示/クリック/CV)

## Test plan
- [x] ローカルで期間変更時の数値アニメーションを確認
- [ ] 本番デプロイ後ダッシュボードで再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)