### PR TITLE
UI/UX 改善: トレンド累積モード・指標tooltip・サイドバーa11y

### DIFF
--- a/app/ad-groups/page.tsx
+++ b/app/ad-groups/page.tsx
@@ -30,6 +30,7 @@ import {
   type Platform,
   type AdType,
 } from '@/lib/campaign-mock-data';
+import { MetricTooltip } from '@/components/ui/metric-tooltip';
 
 // ─── 定数・フォーマット ──────────────────────────────────────────
 
@@ -99,7 +100,6 @@ export default function AdGroupsListPage() {
   // フィルター
   const [platformFilter, setPlatformFilter] = useState<Platform | 'all'>('all');
   const [adTypeFilter, setAdTypeFilter] = useState<AdType | 'all'>('all');
-  const [campaignFilter, setCampaignFilter] = useState<string>('all');
 
   // ソート
   const [sort, setSort] = useState<{ col: SortKey; dir: 'asc' | 'desc' }>({
@@ -115,24 +115,17 @@ export default function AdGroupsListPage() {
     );
   };
 
-  // フィルター適用済みキャンペーンリスト（キャンペーンフィルター用）
-  const filteredCampaigns = useMemo(() => {
-    return CAMPAIGNS.filter((c) => {
-      if (platformFilter !== 'all' && c.platform !== platformFilter) return false;
-      if (adTypeFilter !== 'all' && c.adType !== adTypeFilter) return false;
-      return true;
-    });
-  }, [platformFilter, adTypeFilter]);
-
   // フィルター＋ソート
   const filtered = useMemo(() => {
-    const campaignIds = new Set(filteredCampaigns.map((c) => c.id));
+    const campaignIds = new Set(
+      CAMPAIGNS.filter((c) => {
+        if (platformFilter !== 'all' && c.platform !== platformFilter) return false;
+        if (adTypeFilter !== 'all' && c.adType !== adTypeFilter) return false;
+        return true;
+      }).map((c) => c.id),
+    );
 
-    let result = AD_GROUPS.filter((ag) => {
-      if (!campaignIds.has(ag.campaignId)) return false;
-      if (campaignFilter !== 'all' && ag.campaignId !== campaignFilter) return false;
-      return true;
-    });
+    let result = AD_GROUPS.filter((ag) => campaignIds.has(ag.campaignId));
 
     // campaignName はルックアップで取得
     const getCampaignName = (ag: AdGroupData) => campaignMap.get(ag.campaignId)?.name ?? '';
@@ -156,7 +149,7 @@ export default function AdGroupsListPage() {
     });
 
     return result;
-  }, [filteredCampaigns, campaignFilter, campaignMap, sort]);
+  }, [platformFilter, adTypeFilter, campaignMap, sort]);
 
   // 合計
   const totals = useMemo(() => {
@@ -194,42 +187,38 @@ export default function AdGroupsListPage() {
 
         {/* フィルター */}
         <div className="flex flex-wrap items-center gap-3">
-          <Select value={platformFilter} onValueChange={(v) => { setPlatformFilter(v as Platform | 'all'); setCampaignFilter('all'); }}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="媒体" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">すべての媒体</SelectItem>
-              <SelectItem value="google">Google</SelectItem>
-              <SelectItem value="yahoo">Yahoo!</SelectItem>
-              <SelectItem value="bing">Bing</SelectItem>
-            </SelectContent>
-          </Select>
+          <div className="flex items-center gap-2">
+            <label htmlFor="filter-adtype" className="text-sm text-muted-foreground whitespace-nowrap">
+              種別
+            </label>
+            <Select value={adTypeFilter} onValueChange={(v) => setAdTypeFilter(v as AdType | 'all')}>
+              <SelectTrigger id="filter-adtype" className="h-8 w-36 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべて</SelectItem>
+                <SelectItem value="search">検索</SelectItem>
+                <SelectItem value="display">ディスプレイ</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
-          <Select value={adTypeFilter} onValueChange={(v) => { setAdTypeFilter(v as AdType | 'all'); setCampaignFilter('all'); }}>
-            <SelectTrigger className="w-[160px]">
-              <SelectValue placeholder="種別" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">すべての種別</SelectItem>
-              <SelectItem value="search">検索</SelectItem>
-              <SelectItem value="display">ディスプレイ</SelectItem>
-            </SelectContent>
-          </Select>
-
-          <Select value={campaignFilter} onValueChange={(v) => setCampaignFilter(v ?? 'all')}>
-            <SelectTrigger className="w-[260px]">
-              <SelectValue placeholder="キャンペーン" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">すべてのキャンペーン</SelectItem>
-              {filteredCampaigns.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
-                  {c.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <div className="flex items-center gap-2">
+            <label htmlFor="filter-platform" className="text-sm text-muted-foreground whitespace-nowrap">
+              媒体
+            </label>
+            <Select value={platformFilter} onValueChange={(v) => setPlatformFilter(v as Platform | 'all')}>
+              <SelectTrigger id="filter-platform" className="h-8 w-32 text-sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">すべて</SelectItem>
+                <SelectItem value="google">Google</SelectItem>
+                <SelectItem value="yahoo">Yahoo!</SelectItem>
+                <SelectItem value="bing">Bing</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
 
           <span className="text-sm text-muted-foreground tabular-nums ml-auto">
             {fmtInt.format(filtered.length)} 広告グループ
@@ -315,22 +304,54 @@ export default function AdGroupsListPage() {
                         {ag.clicks > 0 ? fmtInt.format(ag.clicks) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {ag.impressions > 0 ? fmtPct.format(ag.ctr) : '—'}
+                        {ag.impressions > 0 ? (
+                          <MetricTooltip
+                            label="CTR = クリック数 ÷ 表示回数"
+                            numerator={{ label: 'クリック数', value: fmtInt.format(ag.clicks) }}
+                            denominator={{ label: '表示回数', value: fmtInt.format(ag.impressions) }}
+                          >
+                            {fmtPct.format(ag.ctr)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {ag.cost > 0 ? fmtJpy.format(ag.cost) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {ag.clicks > 0 ? fmtJpy.format(ag.cpc) : '—'}
+                        {ag.clicks > 0 ? (
+                          <MetricTooltip
+                            label="平均CPC = 費用 ÷ クリック数"
+                            numerator={{ label: '費用', value: fmtJpy.format(ag.cost) }}
+                            denominator={{ label: 'クリック数', value: fmtInt.format(ag.clicks) }}
+                          >
+                            {fmtJpy.format(ag.cpc)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {ag.conversions > 0 ? fmtInt.format(ag.conversions) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {ag.clicks > 0 ? fmtPct.format(ag.cvr) : '—'}
+                        {ag.clicks > 0 ? (
+                          <MetricTooltip
+                            label="CVR = CV ÷ クリック数"
+                            numerator={{ label: 'CV', value: fmtInt.format(ag.conversions) }}
+                            denominator={{ label: 'クリック数', value: fmtInt.format(ag.clicks) }}
+                          >
+                            {fmtPct.format(ag.cvr)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums pr-4">
-                        {ag.cpa != null ? fmtJpy.format(ag.cpa) : '—'}
+                        {ag.cpa != null ? (
+                          <MetricTooltip
+                            label="CPA = 費用 ÷ CV"
+                            numerator={{ label: '費用', value: fmtJpy.format(ag.cost) }}
+                            denominator={{ label: 'CV', value: fmtInt.format(ag.conversions) }}
+                          >
+                            {fmtJpy.format(ag.cpa)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                     </TableRow>
                   );

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -24,6 +24,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { StatusChip } from '@/components/ui/status-chip';
 import { cn } from '@/lib/utils';
 import { CAMPAIGNS, type CampaignData, type Platform, type AdType } from '@/lib/campaign-mock-data';
+import { MetricTooltip } from '@/components/ui/metric-tooltip';
 
 // ─── 定数 ──────────────────────────────────────────────────────
 
@@ -328,7 +329,15 @@ export default function CampaignsPage() {
 
                       {/* CTR */}
                       <TableCell className="text-right tabular-nums">
-                        {c.impressions > 0 ? fmtPct.format(c.ctr) : '—'}
+                        {c.impressions > 0 ? (
+                          <MetricTooltip
+                            label="CTR = クリック数 ÷ 表示回数"
+                            numerator={{ label: 'クリック数', value: fmtInt.format(c.clicks) }}
+                            denominator={{ label: '表示回数', value: fmtInt.format(c.impressions) }}
+                          >
+                            {fmtPct.format(c.ctr)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
 
                       {/* 費用 */}
@@ -338,7 +347,15 @@ export default function CampaignsPage() {
 
                       {/* 平均CPC */}
                       <TableCell className="text-right tabular-nums">
-                        {c.clicks > 0 ? fmtJpy.format(c.cpc) : '—'}
+                        {c.clicks > 0 ? (
+                          <MetricTooltip
+                            label="平均CPC = 費用 ÷ クリック数"
+                            numerator={{ label: '費用', value: fmtJpy.format(c.cost) }}
+                            denominator={{ label: 'クリック数', value: fmtInt.format(c.clicks) }}
+                          >
+                            {fmtJpy.format(c.cpc)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
 
                       {/* CV */}
@@ -348,7 +365,15 @@ export default function CampaignsPage() {
 
                       {/* CPA */}
                       <TableCell className="text-right tabular-nums pr-4">
-                        {c.cpa != null ? fmtJpy.format(c.cpa) : '—'}
+                        {c.cpa != null ? (
+                          <MetricTooltip
+                            label="CPA = 費用 ÷ CV"
+                            numerator={{ label: '費用', value: fmtJpy.format(c.cost) }}
+                            denominator={{ label: 'CV', value: fmtInt.format(c.conversions) }}
+                          >
+                            {fmtJpy.format(c.cpa)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                     </TableRow>
                   );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -31,6 +31,8 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import {
   LineChart,
   Line,
+  AreaChart,
+  Area,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -41,6 +43,7 @@ import { Chip, Meter, ProgressCircle } from '@heroui/react';
 import { CountingNumber } from '@/components/animate-ui/counting-number';
 import { FunnelFlow } from '@/components/dashboard/funnel-flow';
 import { cn } from '@/lib/utils';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 import {
   aggregateCampaigns,
   aggregateCampaignsByPlatform,
@@ -95,6 +98,8 @@ type BudgetUsage = {
 };
 
 type Anomaly = { type: 'warning' | 'info'; message: string };
+
+type TrendMode = 'daily' | 'cumulative';
 
 // ─── 定数 ──────────────────────────────────────────────────
 
@@ -506,6 +511,37 @@ function defaultDateRange(): DateRangeValue {
   };
 }
 
+function TrendModeToggle({ mode, onChange }: { mode: TrendMode; onChange: (m: TrendMode) => void }) {
+  return (
+    <div
+      role="group"
+      aria-label="トレンド表示モード"
+      className="inline-flex items-center rounded-md border border-border bg-background p-0.5 text-xs font-normal"
+    >
+      {(['daily', 'cumulative'] as const).map((m) => {
+        const active = mode === m;
+        const label = m === 'daily' ? '日別' : '累積';
+        return (
+          <button
+            key={m}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(m)}
+            className={cn(
+              'px-2.5 py-0.5 rounded transition-colors motion-reduce:transition-none',
+              active
+                ? 'bg-muted text-foreground font-medium'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const [dateRange, setDateRange] = useState<DateRangeValue>(defaultDateRange);
   const [platform, setPlatform] = useState<Platform>('all');
@@ -522,11 +558,22 @@ export default function DashboardPage() {
   // 目標CPA（localStorage永続化）
   const [cpaTarget, setCpaTarget] = useState<number | null>(null);
   const [cvTarget, setCvTarget] = useState<number | null>(null);
+  // トレンド表示モード（日別 / 累積）— URL query + localStorage で永続化
+  const [trendMode, setTrendModeState] = useState<TrendMode>('daily');
+  const reducedMotion = usePrefersReducedMotion();
   useEffect(() => {
     const storedCpa = localStorage.getItem('dashboard_cpa_target');
     const storedCv = localStorage.getItem('dashboard_cv_target');
     if (storedCpa) setCpaTarget(Number(storedCpa));
     if (storedCv) setCvTarget(Number(storedCv));
+    const urlMode = new URLSearchParams(window.location.search).get('trendMode');
+    const storedMode = localStorage.getItem('dashboard_trend_mode');
+    const resolved = (urlMode === 'cumulative' || urlMode === 'daily')
+      ? urlMode
+      : (storedMode === 'cumulative' || storedMode === 'daily')
+        ? storedMode
+        : 'daily';
+    setTrendModeState(resolved);
   }, []);
 
   function handleSetCpaTarget(val: number | null) {
@@ -536,6 +583,14 @@ export default function DashboardPage() {
   function handleSetCvTarget(val: number | null) {
     setCvTarget(val);
     val ? localStorage.setItem('dashboard_cv_target', String(val)) : localStorage.removeItem('dashboard_cv_target');
+  }
+  function setTrendMode(mode: TrendMode) {
+    setTrendModeState(mode);
+    localStorage.setItem('dashboard_trend_mode', mode);
+    const url = new URL(window.location.href);
+    if (mode === 'daily') url.searchParams.delete('trendMode');
+    else url.searchParams.set('trendMode', mode);
+    window.history.replaceState(null, '', url.toString());
   }
 
   const fetchData = useCallback(
@@ -619,19 +674,53 @@ export default function DashboardPage() {
   const deltaLabel = dateRange.compareEnabled ? '比較期間比' : '前期間比';
   const anomalies = isMock ? [] : buildAnomalies(current, previous, budget, cpaTarget);
 
-  // 比較トレンドをインデックス合わせでマージ
+  // 比較トレンドをインデックス合わせでマージ + 累積計算
   const showCompare = dateRange.compareEnabled && compareTrend.length > 0;
-  const chartData = displayTrend.map((d, i) => {
-    const cmp = compareTrend[i];
-    return {
-      ...d,
-      label: dateShort.format(new Date(d.date)),
-      cpaTargetLine: cpaTarget ?? undefined,
-      cmp_cpa: cmp?.cpa ?? null,
-      cmp_cv: cmp?.conversions ?? null,
-      cmp_date: cmp?.date ?? null,
-    };
-  });
+  const chartData = useMemo(() => {
+    let cumCost = 0;
+    let cumCv = 0;
+    let cumGoogleCost = 0;
+    let cumYahooCost = 0;
+    let cumBingCost = 0;
+    let cumGoogleCv = 0;
+    let cumYahooCv = 0;
+    let cumBingCv = 0;
+    let cumCmpCost = 0;
+    let cumCmpCv = 0;
+    return displayTrend.map((d, i) => {
+      const cmp = compareTrend[i];
+      cumCost += d.cost;
+      cumCv += d.conversions;
+      cumGoogleCost += d.google;
+      cumYahooCost += d.yahoo;
+      cumBingCost += d.bing;
+      cumGoogleCv += d.google_cv;
+      cumYahooCv += d.yahoo_cv;
+      cumBingCv += d.bing_cv;
+      if (cmp) {
+        cumCmpCost += cmp.cost;
+        cumCmpCv += cmp.conversions;
+      }
+      return {
+        ...d,
+        label: dateShort.format(new Date(d.date)),
+        cpaTargetLine: cpaTarget ?? undefined,
+        cmp_cpa: cmp?.cpa ?? null,
+        cmp_cv: cmp?.conversions ?? null,
+        cmp_date: cmp?.date ?? null,
+        cpa_cum: cumCv > 0 ? Math.round(cumCost / cumCv) : null,
+        cv_cum: cumCv,
+        google_cv_cum: cumGoogleCv,
+        yahoo_cv_cum: cumYahooCv,
+        bing_cv_cum: cumBingCv,
+        google_cpa_cum: cumGoogleCv > 0 ? Math.round(cumGoogleCost / cumGoogleCv) : null,
+        yahoo_cpa_cum: cumYahooCv > 0 ? Math.round(cumYahooCost / cumYahooCv) : null,
+        bing_cpa_cum: cumBingCv > 0 ? Math.round(cumBingCost / cumBingCv) : null,
+        cmp_cpa_cum: cmp ? (cumCmpCv > 0 ? Math.round(cumCmpCost / cumCmpCv) : null) : null,
+        cmp_cv_cum: cmp ? cumCmpCv : null,
+      };
+    });
+  }, [displayTrend, compareTrend, cpaTarget]);
 
 
   // 最終更新テキスト
@@ -855,13 +944,16 @@ export default function DashboardPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <Card>
             <CardHeader>
-              <CardTitle className="text-base flex items-center justify-between">
-                CPA推移
-                {cpaTarget && (
-                  <span className="text-xs font-normal text-muted-foreground/60 tabular-nums">
-                    目標 {jpyFormat.format(cpaTarget)}
-                  </span>
-                )}
+              <CardTitle className="text-base flex items-center justify-between gap-2">
+                <span className="flex items-center gap-2">
+                  CPA推移
+                  {cpaTarget && (
+                    <span className="text-xs font-normal text-muted-foreground/60 tabular-nums">
+                      目標 {jpyFormat.format(cpaTarget)}
+                    </span>
+                  )}
+                </span>
+                <TrendModeToggle mode={trendMode} onChange={setTrendMode} />
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -880,15 +972,21 @@ export default function DashboardPage() {
                     content={({ active, payload, label }) => {
                       if (!active || !payload?.length) return null;
                       const d = payload[0].payload as typeof chartData[0];
+                      const isCum = trendMode === 'cumulative';
+                      const cpaVal = isCum ? d.cpa_cum : d.cpa;
+                      const cmpCpaVal = isCum ? d.cmp_cpa_cum : d.cmp_cpa;
                       return (
                         <div className="rounded-lg border border-border bg-background shadow-md p-3 text-xs space-y-1.5 min-w-[180px]">
-                          <p className="font-medium text-foreground">{label}</p>
+                          <p className="font-medium text-foreground">
+                            {label}
+                            {isCum && <span className="ml-1.5 text-muted-foreground font-normal">（期間累計）</span>}
+                          </p>
                           <div className="flex justify-between gap-4">
                             <span className="flex items-center gap-1.5">
                               <span className="w-2 h-2 rounded-full bg-[#6366f1] shrink-0" />
                               <span className="text-muted-foreground">表示期間</span>
                             </span>
-                            <span className="tabular-nums font-semibold">{d.cpa != null ? jpyFormat.format(d.cpa) : '—'}</span>
+                            <span className="tabular-nums font-semibold">{cpaVal != null ? jpyFormat.format(cpaVal) : '—'}</span>
                           </div>
                           {showCompare && (
                             <div className="flex justify-between gap-4">
@@ -898,20 +996,23 @@ export default function DashboardPage() {
                                   比較{d.cmp_date ? `（${dateShort.format(new Date(d.cmp_date))}）` : ''}
                                 </span>
                               </span>
-                              <span className="tabular-nums">{d.cmp_cpa != null ? jpyFormat.format(d.cmp_cpa) : '—'}</span>
+                              <span className="tabular-nums">{cmpCpaVal != null ? jpyFormat.format(cmpCpaVal) : '—'}</span>
                             </div>
                           )}
                           {platform === 'all' && (
                             <div className="pt-1 border-t border-border/50 space-y-1.5">
-                              {(['google', 'yahoo', 'bing'] as const).map((p) => (
-                                <div key={p} className="flex justify-between gap-4">
-                                  <span className="flex items-center gap-1.5">
-                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: PLATFORM_COLORS[p] }} />
-                                    <span className="text-muted-foreground">{PLATFORM_LABELS[p]}</span>
-                                  </span>
-                                  <span className="tabular-nums">{d[`${p}_cpa`] != null ? jpyFormat.format(d[`${p}_cpa`]!) : '—'}</span>
-                                </div>
-                              ))}
+                              {(['google', 'yahoo', 'bing'] as const).map((p) => {
+                                const v = isCum ? d[`${p}_cpa_cum`] : d[`${p}_cpa`];
+                                return (
+                                  <div key={p} className="flex justify-between gap-4">
+                                    <span className="flex items-center gap-1.5">
+                                      <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: PLATFORM_COLORS[p] }} />
+                                      <span className="text-muted-foreground">{PLATFORM_LABELS[p]}</span>
+                                    </span>
+                                    <span className="tabular-nums">{v != null ? jpyFormat.format(v) : '—'}</span>
+                                  </div>
+                                );
+                              })}
                             </div>
                           )}
                           {cpaTarget && (
@@ -934,28 +1035,31 @@ export default function DashboardPage() {
                       strokeWidth={1.5}
                       strokeDasharray="5 4"
                       dot={false}
+                      isAnimationActive={!reducedMotion}
                     />
                   )}
                   {showCompare && (
                     <Line
                       type="monotone"
-                      dataKey="cmp_cpa"
+                      dataKey={trendMode === 'cumulative' ? 'cmp_cpa_cum' : 'cmp_cpa'}
                       name="比較期間"
                       stroke="#f97316"
                       strokeWidth={1.5}
                       strokeDasharray="5 3"
                       dot={false}
                       connectNulls
+                      isAnimationActive={!reducedMotion}
                     />
                   )}
                   <Line
                     type="monotone"
-                    dataKey="cpa"
+                    dataKey={trendMode === 'cumulative' ? 'cpa_cum' : 'cpa'}
                     name="表示期間"
                     stroke="#6366f1"
                     strokeWidth={2}
-                    dot={{ r: 3, fill: '#6366f1' }}
+                    dot={trendMode === 'cumulative' ? false : { r: 3, fill: '#6366f1' }}
                     connectNulls
+                    isAnimationActive={!reducedMotion}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -965,84 +1069,198 @@ export default function DashboardPage() {
           {/* CV推移 */}
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">CV推移</CardTitle>
+              <CardTitle className="text-base flex items-center justify-between gap-2">
+                CV推移
+                <TrendModeToggle mode={trendMode} onChange={setTrendMode} />
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <ResponsiveContainer width="100%" height={220}>
-                <LineChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border) / 0.5)" />
-                  <XAxis dataKey="label" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
-                  <YAxis
-                    tick={{ fontSize: 11 }}
-                    tickFormatter={(v) => numFormat.format(v)}
-                    width={36}
-                    axisLine={false}
-                    tickLine={false}
-                  />
-                  <Tooltip
-                    content={({ active, payload, label }) => {
-                      if (!active || !payload?.length) return null;
-                      const d = payload[0].payload as typeof chartData[0];
-                      return (
-                        <div className="rounded-lg border border-border bg-background shadow-md p-3 text-xs space-y-1.5 min-w-[180px]">
-                          <p className="font-medium text-foreground">{label}</p>
-                          <div className="flex justify-between gap-4">
-                            <span className="flex items-center gap-1.5">
-                              <span className="w-2 h-2 rounded-full bg-[#10b981] shrink-0" />
-                              <span className="text-muted-foreground">表示期間</span>
-                            </span>
-                            <span className="tabular-nums font-semibold">{numFormat.format(d.conversions)}</span>
-                          </div>
-                          {showCompare && (
+                {trendMode === 'cumulative' ? (
+                  <AreaChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+                    <defs>
+                      {(['google', 'yahoo', 'bing'] as const).map((p) => (
+                        <linearGradient key={p} id={`cv-cum-${p}`} x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor={PLATFORM_COLORS[p]} stopOpacity={0.5} />
+                          <stop offset="100%" stopColor={PLATFORM_COLORS[p]} stopOpacity={0.08} />
+                        </linearGradient>
+                      ))}
+                      <linearGradient id="cv-cum-single" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#10b981" stopOpacity={0.5} />
+                        <stop offset="100%" stopColor="#10b981" stopOpacity={0.05} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border) / 0.5)" />
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
+                    <YAxis
+                      tick={{ fontSize: 11 }}
+                      tickFormatter={(v) => numFormat.format(v)}
+                      width={36}
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }) => {
+                        if (!active || !payload?.length) return null;
+                        const d = payload[0].payload as typeof chartData[0];
+                        return (
+                          <div className="rounded-lg border border-border bg-background shadow-md p-3 text-xs space-y-1.5 min-w-[180px]">
+                            <p className="font-medium text-foreground">
+                              {label}
+                              <span className="ml-1.5 text-muted-foreground font-normal">（期間累計）</span>
+                            </p>
                             <div className="flex justify-between gap-4">
                               <span className="flex items-center gap-1.5">
-                                <span className="w-2 h-2 rounded-full bg-[#f97316] shrink-0" />
-                                <span className="text-muted-foreground">
-                                  比較{d.cmp_date ? `（${dateShort.format(new Date(d.cmp_date))}）` : ''}
-                                </span>
+                                <span className="w-2 h-2 rounded-full bg-[#10b981] shrink-0" />
+                                <span className="text-muted-foreground">表示期間</span>
                               </span>
-                              <span className="tabular-nums">{d.cmp_cv != null ? numFormat.format(d.cmp_cv) : '—'}</span>
+                              <span className="tabular-nums font-semibold">{numFormat.format(d.cv_cum)}</span>
                             </div>
-                          )}
-                          {platform === 'all' && (
-                            <div className="pt-1 border-t border-border/50 space-y-1.5">
-                              {(['google', 'yahoo', 'bing'] as const).map((p) => (
-                                <div key={p} className="flex justify-between gap-4">
-                                  <span className="flex items-center gap-1.5">
-                                    <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: PLATFORM_COLORS[p] }} />
-                                    <span className="text-muted-foreground">{PLATFORM_LABELS[p]}</span>
+                            {showCompare && (
+                              <div className="flex justify-between gap-4">
+                                <span className="flex items-center gap-1.5">
+                                  <span className="w-2 h-2 rounded-full bg-[#f97316] shrink-0" />
+                                  <span className="text-muted-foreground">
+                                    比較{d.cmp_date ? `（${dateShort.format(new Date(d.cmp_date))}）` : ''}
                                   </span>
-                                  <span className="tabular-nums">{numFormat.format(d[`${p}_cv`])}</span>
-                                </div>
-                              ))}
+                                </span>
+                                <span className="tabular-nums">{d.cmp_cv_cum != null ? numFormat.format(d.cmp_cv_cum) : '—'}</span>
+                              </div>
+                            )}
+                            {platform === 'all' && (
+                              <div className="pt-1 border-t border-border/50 space-y-1.5">
+                                {(['google', 'yahoo', 'bing'] as const).map((p) => (
+                                  <div key={p} className="flex justify-between gap-4">
+                                    <span className="flex items-center gap-1.5">
+                                      <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: PLATFORM_COLORS[p] }} />
+                                      <span className="text-muted-foreground">{PLATFORM_LABELS[p]}</span>
+                                    </span>
+                                    <span className="tabular-nums">{numFormat.format(d[`${p}_cv_cum`])}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      }}
+                    />
+                    {showCompare && (
+                      <Area
+                        type="monotone"
+                        dataKey="cmp_cv_cum"
+                        name="比較期間"
+                        stroke="#f97316"
+                        strokeWidth={1.5}
+                        strokeDasharray="5 3"
+                        fill="#f97316"
+                        fillOpacity={0.05}
+                        isAnimationActive={!reducedMotion}
+                      />
+                    )}
+                    {platform === 'all' ? (
+                      (['google', 'yahoo', 'bing'] as const).map((p) => (
+                        <Area
+                          key={p}
+                          type="monotone"
+                          dataKey={`${p}_cv_cum`}
+                          name={PLATFORM_LABELS[p]}
+                          stackId="cv"
+                          stroke={PLATFORM_COLORS[p]}
+                          strokeWidth={1.5}
+                          fill={`url(#cv-cum-${p})`}
+                          isAnimationActive={!reducedMotion}
+                        />
+                      ))
+                    ) : (
+                      <Area
+                        type="monotone"
+                        dataKey="cv_cum"
+                        name="表示期間"
+                        stroke="#10b981"
+                        strokeWidth={2}
+                        fill="url(#cv-cum-single)"
+                        isAnimationActive={!reducedMotion}
+                      />
+                    )}
+                  </AreaChart>
+                ) : (
+                  <LineChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border) / 0.5)" />
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
+                    <YAxis
+                      tick={{ fontSize: 11 }}
+                      tickFormatter={(v) => numFormat.format(v)}
+                      width={36}
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }) => {
+                        if (!active || !payload?.length) return null;
+                        const d = payload[0].payload as typeof chartData[0];
+                        return (
+                          <div className="rounded-lg border border-border bg-background shadow-md p-3 text-xs space-y-1.5 min-w-[180px]">
+                            <p className="font-medium text-foreground">{label}</p>
+                            <div className="flex justify-between gap-4">
+                              <span className="flex items-center gap-1.5">
+                                <span className="w-2 h-2 rounded-full bg-[#10b981] shrink-0" />
+                                <span className="text-muted-foreground">表示期間</span>
+                              </span>
+                              <span className="tabular-nums font-semibold">{numFormat.format(d.conversions)}</span>
                             </div>
-                          )}
-                        </div>
-                      );
-                    }}
-                  />
-                  {showCompare && (
+                            {showCompare && (
+                              <div className="flex justify-between gap-4">
+                                <span className="flex items-center gap-1.5">
+                                  <span className="w-2 h-2 rounded-full bg-[#f97316] shrink-0" />
+                                  <span className="text-muted-foreground">
+                                    比較{d.cmp_date ? `（${dateShort.format(new Date(d.cmp_date))}）` : ''}
+                                  </span>
+                                </span>
+                                <span className="tabular-nums">{d.cmp_cv != null ? numFormat.format(d.cmp_cv) : '—'}</span>
+                              </div>
+                            )}
+                            {platform === 'all' && (
+                              <div className="pt-1 border-t border-border/50 space-y-1.5">
+                                {(['google', 'yahoo', 'bing'] as const).map((p) => (
+                                  <div key={p} className="flex justify-between gap-4">
+                                    <span className="flex items-center gap-1.5">
+                                      <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: PLATFORM_COLORS[p] }} />
+                                      <span className="text-muted-foreground">{PLATFORM_LABELS[p]}</span>
+                                    </span>
+                                    <span className="tabular-nums">{numFormat.format(d[`${p}_cv`])}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      }}
+                    />
+                    {showCompare && (
+                      <Line
+                        type="monotone"
+                        dataKey="cmp_cv"
+                        name="比較期間"
+                        stroke="#f97316"
+                        strokeWidth={1.5}
+                        strokeDasharray="5 3"
+                        dot={false}
+                        connectNulls
+                        isAnimationActive={!reducedMotion}
+                      />
+                    )}
                     <Line
                       type="monotone"
-                      dataKey="cmp_cv"
-                      name="比較期間"
-                      stroke="#f97316"
-                      strokeWidth={1.5}
-                      strokeDasharray="5 3"
-                      dot={false}
+                      dataKey="conversions"
+                      name="表示期間"
+                      stroke="#10b981"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: '#10b981' }}
                       connectNulls
+                      isAnimationActive={!reducedMotion}
                     />
-                  )}
-                  <Line
-                    type="monotone"
-                    dataKey="conversions"
-                    name="表示期間"
-                    stroke="#10b981"
-                    strokeWidth={2}
-                    dot={{ r: 3, fill: '#10b981' }}
-                    connectNulls
-                  />
-                </LineChart>
+                  </LineChart>
+                )}
               </ResponsiveContainer>
             </CardContent>
           </Card>

--- a/app/keywords/page.tsx
+++ b/app/keywords/page.tsx
@@ -30,6 +30,7 @@ import {
   type KeywordData,
   type Platform,
 } from '@/lib/campaign-mock-data';
+import { MetricTooltip } from '@/components/ui/metric-tooltip';
 
 // ─── 定数・フォーマット ──────────────────────────────────────────
 
@@ -333,22 +334,54 @@ export default function KeywordsListPage() {
                         {kw.clicks > 0 ? fmtInt.format(kw.clicks) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {kw.impressions > 0 ? fmtPct.format(kw.ctr) : '—'}
+                        {kw.impressions > 0 ? (
+                          <MetricTooltip
+                            label="CTR = クリック数 ÷ 表示回数"
+                            numerator={{ label: 'クリック数', value: fmtInt.format(kw.clicks) }}
+                            denominator={{ label: '表示回数', value: fmtInt.format(kw.impressions) }}
+                          >
+                            {fmtPct.format(kw.ctr)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {kw.cost > 0 ? fmtJpy.format(kw.cost) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {kw.clicks > 0 ? fmtJpy.format(kw.cpc) : '—'}
+                        {kw.clicks > 0 ? (
+                          <MetricTooltip
+                            label="CPC = 費用 ÷ クリック数"
+                            numerator={{ label: '費用', value: fmtJpy.format(kw.cost) }}
+                            denominator={{ label: 'クリック数', value: fmtInt.format(kw.clicks) }}
+                          >
+                            {fmtJpy.format(kw.cpc)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {kw.conversions > 0 ? fmtInt.format(kw.conversions) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
-                        {kw.clicks > 0 ? fmtPct.format(kw.cvr) : '—'}
+                        {kw.clicks > 0 ? (
+                          <MetricTooltip
+                            label="CVR = CV ÷ クリック数"
+                            numerator={{ label: 'CV', value: fmtInt.format(kw.conversions) }}
+                            denominator={{ label: 'クリック数', value: fmtInt.format(kw.clicks) }}
+                          >
+                            {fmtPct.format(kw.cvr)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                       <TableCell className="text-right tabular-nums pr-4">
-                        {kw.cpa != null ? fmtJpy.format(kw.cpa) : '—'}
+                        {kw.cpa != null ? (
+                          <MetricTooltip
+                            label="CPA = 費用 ÷ CV"
+                            numerator={{ label: '費用', value: fmtJpy.format(kw.cost) }}
+                            denominator={{ label: 'CV', value: fmtInt.format(kw.conversions) }}
+                          >
+                            {fmtJpy.format(kw.cpa)}
+                          </MetricTooltip>
+                        ) : '—'}
                       </TableCell>
                     </TableRow>
                   );

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { Sidebar } from './Sidebar';
 import { Toaster } from 'sonner';
 import { PageTransition } from '@/components/animate-ui/page-transition';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 type SidebarContextValue = {
   collapsed: boolean;
@@ -46,21 +47,23 @@ export function MainLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <SidebarContext.Provider value={{ collapsed, setCollapsed, ready }}>
-      <div className="flex min-h-screen items-start bg-slate-50">
-        <Sidebar />
-        <main className="flex-1 min-w-0">
-          <div className="p-6">
-            <PageTransition>{children}</PageTransition>
-          </div>
-        </main>
-        <Toaster
-          richColors
-          closeButton
-          position="top-right"
-          duration={4000}
-          toastOptions={{ classNames: { toast: 'rounded-lg' } }}
-        />
-      </div>
+      <TooltipProvider delay={200}>
+        <div className="flex min-h-screen items-start bg-slate-50">
+          <Sidebar />
+          <main className="flex-1 min-w-0">
+            <div className="p-6">
+              <PageTransition>{children}</PageTransition>
+            </div>
+          </main>
+          <Toaster
+            richColors
+            closeButton
+            position="top-right"
+            duration={4000}
+            toastOptions={{ classNames: { toast: 'rounded-lg' } }}
+          />
+        </div>
+      </TooltipProvider>
     </SidebarContext.Provider>
   );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { useSidebarCollapsed } from './MainLayout';
+import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion';
 
 type NavItem = {
   href: string;
@@ -107,6 +108,7 @@ function formatSyncTime(iso: string | null): string {
 export function Sidebar() {
   const pathname = usePathname();
   const { collapsed, setCollapsed, ready } = useSidebarCollapsed();
+  const reducedMotion = usePrefersReducedMotion();
   const [syncStatuses, setSyncStatuses] = useState<SyncStatus[]>([
     { platform: 'google', lastSync: null, status: 'never' },
     { platform: 'yahoo', lastSync: null, status: 'never' },
@@ -123,7 +125,8 @@ export function Sidebar() {
   }, []);
 
   // ready がtrueになるまでアニメーションなし（初期フラッシュ防止）
-  const animate = ready;
+  // prefers-reduced-motion の場合も無効化
+  const animate = ready && !reducedMotion;
 
   return (
     <aside
@@ -216,8 +219,8 @@ export function Sidebar() {
                     <span
                       className={cn(
                         'flex-1 whitespace-nowrap overflow-hidden',
-                        animate && 'transition-[opacity,max-width] duration-300 ease-in-out',
-                        collapsed ? 'opacity-0 max-w-0' : 'opacity-100 max-w-48',
+                        animate && 'transition-[opacity,max-width,transform] duration-300 ease-in-out',
+                        collapsed ? 'opacity-0 max-w-0 -translate-x-1' : 'opacity-100 max-w-48 translate-x-0',
                       )}
                     >
                       {label}

--- a/components/ui/metric-tooltip.tsx
+++ b/components/ui/metric-tooltip.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+type MetricTooltipProps = {
+  label: string;
+  numerator: { label: string; value: string };
+  denominator: { label: string; value: string };
+  children: React.ReactNode;
+};
+
+export function MetricTooltip({ label, numerator, denominator, children }: MetricTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            tabIndex={0}
+            className="cursor-help outline-hidden focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent className="px-3 py-2">
+        <div className="space-y-1 min-w-[140px]">
+          <p className="text-[11px] font-semibold">{label}</p>
+          <div className="flex items-center justify-between gap-3 text-[11px]">
+            <span className="opacity-70">{numerator.label}</span>
+            <span className="tabular-nums">{numerator.value}</span>
+          </div>
+          <div className="flex items-center justify-between gap-3 text-[11px]">
+            <span className="opacity-70">{denominator.label}</span>
+            <span className="tabular-nums">{denominator.value}</span>
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/hooks/use-prefers-reduced-motion.ts
+++ b/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
## Summary
- #37 ダッシュボード CPA/CV 推移チャートに「日別／累積」モードトグルを追加（URL / localStorage 永続化、累積 CV は stacked AreaChart）
- #21 サイドバー折りたたみの `prefers-reduced-motion` 対応とラベルのスライド感強化
- #22 キャンペーン／広告グループ／キーワード一覧の CTR・CPC・CVR・CPA セルに hover tooltip を追加（内訳表示、キーボードフォーカス対応）
- #26 #27 広告グループ一覧のキャンペーンフィルター削除、残フィルターにラベル追加してキャンペーン画面と統一

Closes #21 #22 #26 #27 #37

## Test plan
- [ ] `/dashboard` を開き、CPA推移／CV推移カード右上の「日別／累積」トグルで切替できる
- [ ] 累積モードで CV は Google / Yahoo! / Bing の stacked area、CPA は滑らかな単一ライン
- [ ] `?trendMode=cumulative` URL で直接開いて累積モードで初期化される
- [ ] サイドバーを折りたたみ／展開するとスライド＋ラベルフェードが入る
- [ ] OS 設定で動きを減らすと サイドバーとチャートのトランジションが無効化される
- [ ] 各一覧画面で CTR／CPC／CVR／CPA セルにホバーすると分子・分母の内訳 tooltip が 200ms 後に表示される
- [ ] Tab キーで tooltip トリガーにフォーカスした際も tooltip が表示される
- [ ] `/ad-groups` のキャンペーンフィルターが消えており、種別・媒体フィルターにラベルが付いている

🤖 Generated with [Claude Code](https://claude.com/claude-code)